### PR TITLE
Autofilter #2: Update zcl_excel_writer_2007 to run with multiple values for multiple columns

### DIFF
--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -4212,10 +4212,11 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
     DATA: col_count              TYPE int4,
           lo_autofilters         TYPE REF TO zcl_excel_autofilters,
           lo_autofilter          TYPE REF TO zcl_excel_autofilter,
-          l_autofilter_hidden    TYPE flag,
           lt_values              TYPE zexcel_t_autofilter_values,
           ls_values              TYPE zexcel_s_autofilter_values,
           ls_area                TYPE zexcel_s_autofilter_area,
+          lt_filter_cols         TYPE SORTED TABLE OF zexcel_cell_column WITH UNIQUE KEY table_line,
+          lt_cols2match          LIKE lt_filter_cols,
 
           lo_iterator            TYPE REF TO zcl_excel_collection_iterator,
           lo_table               TYPE REF TO zcl_excel_table,
@@ -4263,7 +4264,9 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
     IF lo_autofilter IS BOUND.
       lt_values           = lo_autofilter->get_values( ) .
       ls_area             = lo_autofilter->get_filter_area( ) .
-      l_autofilter_hidden = abap_true. " First defautl is not showing
+      LOOP AT lt_values INTO ls_values.
+        INSERT ls_values-column INTO TABLE lt_filter_cols.
+      ENDLOOP.
     ENDIF.
 *--------------------------------------------------------------------*
 *issue #220 - If cell in tables-area don't use default from row or column or sheet - Coding 1 - start
@@ -4326,14 +4329,6 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
 
     CLEAR ls_sheet_content.
     LOOP AT io_worksheet->sheet_content INTO ls_sheet_content.
-      IF lt_values IS INITIAL. " no values attached to autofilter  " issue #368 autofilter filtering too much
-        CLEAR l_autofilter_hidden.
-      ELSE.
-        READ TABLE lt_values INTO ls_values WITH KEY column = ls_last_row-cell_column.
-        IF sy-subrc = 0 AND ls_values-value = ls_last_row-cell_value.
-          CLEAR l_autofilter_hidden.
-        ENDIF.
-      ENDIF.
       CLEAR ls_style_mapping.
 *Create row element
 *issues #346,#154, #195  - problems when we have information in row_dimension but no cell content in that row
@@ -4364,18 +4359,10 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
         ENDIF.
 
         IF ls_last_row-cell_row NE <ls_sheet_content>-cell_row.
-          IF lo_autofilter IS BOUND.
-            IF ls_area-row_start >=  ls_last_row-cell_row OR " One less for header
-              ls_area-row_end   < ls_last_row-cell_row .
-              CLEAR l_autofilter_hidden.
-            ENDIF.
-          ELSE.
-            CLEAR l_autofilter_hidden.
-          ENDIF.
           IF ls_last_row-cell_row IS NOT INITIAL.
             " Row visibility of previos row.
             IF lo_row->get_visible( io_worksheet ) = abap_false OR
-               l_autofilter_hidden = abap_true.
+               lt_cols2match IS NOT INITIAL.
               lo_element_2->set_attribute_ns( name  = 'hidden' value = 'true' ).
             ENDIF.
             rv_ixml_sheet_data_root->append_child( new_child = lo_element_2 ). " row node
@@ -4423,15 +4410,28 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
             lo_element_2->set_attribute_ns( name  = 's' value = lv_value ).
             lo_element_2->set_attribute_ns( name  = 'customFormat'  value = '1' ).
           ENDIF.
-          IF lt_values IS INITIAL. " no values attached to autofilter  " issue #368 autofilter filtering too much
-            CLEAR l_autofilter_hidden.
-          ELSE.
-            l_autofilter_hidden = abap_true. " First default is not showing
+          IF lo_autofilter IS BOUND.
+            IF ls_area-row_start <  <ls_sheet_content>-cell_row AND  "One less for header
+               ls_area-row_end   >= <ls_sheet_content>-cell_row.
+              " First default is not showing
+              lt_cols2match = lt_filter_cols.
+            ELSE.
+              CLEAR lt_cols2match.
+            ENDIF.
           ENDIF.
         ELSE.
 
         ENDIF.
+        ls_last_row = <ls_sheet_content>.
       ENDWHILE.
+
+      READ TABLE lt_values TRANSPORTING NO FIELDS
+                           WITH KEY column = <ls_sheet_content>-cell_column
+                                    value  = <ls_sheet_content>-cell_value
+                           BINARY SEARCH.
+      IF sy-subrc = 0.
+        DELETE TABLE lt_cols2match WITH TABLE KEY table_line = <ls_sheet_content>-cell_column.
+      ENDIF.
 
       lo_element_3 = io_document->create_simple_element( name   = lc_xml_node_c
                                                          parent = io_document ).
@@ -4537,24 +4537,11 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
       ENDIF.
 
       lo_element_2->append_child( new_child = lo_element_3 ). " column node
-      ls_last_row = <ls_sheet_content>.
     ENDLOOP.
     IF sy-subrc = 0.
-      READ TABLE lt_values INTO ls_values WITH KEY column = ls_last_row-cell_column.
-      IF sy-subrc = 0 AND ls_values-value = ls_last_row-cell_value.
-        CLEAR l_autofilter_hidden.
-      ENDIF.
-      IF lo_autofilter IS BOUND.
-        IF ls_area-row_start >=  ls_last_row-cell_row OR " One less for header
-          ls_area-row_end   < ls_last_row-cell_row .
-          CLEAR l_autofilter_hidden.
-        ENDIF.
-      ELSE.
-        CLEAR l_autofilter_hidden.
-      ENDIF.
       " Row visibility of previos row.
       IF lo_row->get_visible( ) = abap_false OR
-         l_autofilter_hidden = abap_true.
+         lt_cols2match IS NOT INITIAL.
         lo_element_2->set_attribute_ns( name  = 'hidden' value = 'true' ).
       ENDIF.
       rv_ixml_sheet_data_root->append_child( new_child = lo_element_2 ). " row node


### PR DESCRIPTION
Old field l_autofilter_hidden = 'X' is now represented by an entry for each filter column in table lt_cols2match.